### PR TITLE
Modify GC handling.

### DIFF
--- a/src/gc.c
+++ b/src/gc.c
@@ -499,7 +499,9 @@ gc_mark_children(mrb_state *mrb, struct RBasic *obj)
   case MRB_TT_FILE:
     {
       struct RFile *f = (struct RFile*)obj;
-      mrb_gc_mark_value(mrb, f->fptr->path);
+      if (f->fptr) {
+        mrb_gc_mark_value(mrb, f->fptr->path);
+      }
     }
     break;
 #endif


### PR DESCRIPTION
このパッチと、 mruby/mruby の [#803](https://github.com/mruby/mruby/issues/803) と [#805](https://github.com/mruby/mruby/pull/805) を適用すると、Ubuntu 32bit で
Segmentation Fault しなくなると思います。

正規表現部分については詳細をまだ把握できていないですが、`mrb->local_svar` を
 root_scan の対象にする必要があるかもしれません。
